### PR TITLE
Fix pending API requests hang on token refresh failure

### DIFF
--- a/src/background/services/api/APIService.ts
+++ b/src/background/services/api/APIService.ts
@@ -115,7 +115,8 @@ export class APIService implements IAPIService {
               attemptNumber: attemptNumber + 1,
             });
           } catch (refreshError: unknown) {
-            // Token refresh failed, reject all pending requests
+            // Token refresh failed, resolve any pending requests so they don't hang
+            this.pendingRequests.forEach(resolve => resolve());
             this.pendingRequests = [];
 
             if (


### PR DESCRIPTION
## Summary
- ensure pending API requests resume when token refresh fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840bf8bbfdc832ea91b5b1c68b728aa